### PR TITLE
readme: fix type for seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Make sure to run:
 
 * `bundle install`
 
-* `rails db:seeds`
+* `rails db:seed`


### PR DESCRIPTION
Hi @reireynoso , fixed typo for `rails db:seed`